### PR TITLE
fix: configure kicking out concurrent users per hospital and reorganize hospital list

### DIFF
--- a/env/opal.config.sample.js
+++ b/env/opal.config.sample.js
@@ -15,8 +15,6 @@ const config = {
         // For testing purposes (e.g., if no external server is setup), it's possible to provide a path to
         // a local configuration file (e.g., `./content/content.config.json`).
         externalContentFileURL: "./content/content.config.json",
-        // Boolean: whether to kick out a user when another person logs into the same user account on another device.
-        kickOutConcurrentUsers: false,
         // String: the service status URL is used to display a 'service status message' to the user when they log in.
         // Leave empty if no service status URL has been set on the external server.
         // E.g., https://<YOUR-EXTERNAL-HOST>/<PATH-TO-THE-SERVICE-STATUS>
@@ -25,8 +23,8 @@ const config = {
         serviceStatusURL: "./content/service-status.json",
         // Boolean: whether to show the app's version and build number on the front page.
         showVersionOnInit: true,
-        // Boolean: whether to use real (production-ready) institution names and acronyms (such as "RI-MUHC"). If false, generic names are used.
-        useRealInstitutionNames: false,
+        // Boolean: whether to use real (production-ready) hospitals for login. If false, development-specific hospitals are used instead.
+        useProductionHospitals: false,
         // Boolean: whether to use a sourcemap when building the web code. Should be false in production.
         useSourceMap: true,
         // Boolean: whether screenshots can be taken in the app. Should be false in production.

--- a/src/Languages/appTranslationTablesViews/login/en.json
+++ b/src/Languages/appTranslationTablesViews/login/en.json
@@ -63,8 +63,6 @@
   "NEWPASSWORD": "Set Password",
   "NO_PAGE_CONTENT": "There is currently no content available for this page. Please contact the hospital for more information.",
   "NOINTERNETCONNECTION": "You are currently offline",
-  "OHIGPH": "OHIGPH",
-  "OHIGPH_FULL": "OHIG Pediatric Hospital",
   "OK": "Ok",
   "OK_BUTTON": "OK",
   "OMI": "OMI",

--- a/src/Languages/appTranslationTablesViews/login/fr.json
+++ b/src/Languages/appTranslationTablesViews/login/fr.json
@@ -63,8 +63,6 @@
   "NEWPASSWORD": "Créez un mot de passe",
   "NO_PAGE_CONTENT": "Il n'y a présentement aucun contenu sur cette page. Veuillez contacter l'hôpital pour plus d'information.",
   "NOINTERNETCONNECTION": "Pas de connexion Internet",
-  "OHIGPH": "HPOHIG",
-  "OHIGPH_FULL": "Hôpital pédiatrique OHIG",
   "OK": "D'accord",
   "OK_BUTTON": "OK",
   "OMI": "ÉMO",

--- a/src/js/app.values.js
+++ b/src/js/app.values.js
@@ -96,42 +96,53 @@
                 },
 
                 /** Multi-institutional hospital modules and codes **/
-                allowedModulesBeforeLogin: {
-                    "DIA": 0, // Diagnoses
-                    "APT": 0, // Appointments
-                    "LAB": 0, // Lab results
-                    "DOC": 0, // Documents (clinical reports)
-                    "TTM": 0, // Treating team messages
-                    "QUE": 0, // Questionnaires
-                    "CSQ": 0, // Carnet Santé Québec
-                    "RES": 0, // Research menu
-                    "STU": 0, // Research studies
-                    "REF": 0, // Research reference material
-                    "RQU": 0, // Research questionnaires
-                    "CON": 0, // Research consent forms
-                    "CHK": 0, // Check-in
-                    "ABT": 1, // About Opal
-                    "NTF": 0, // Notifications
-                    "ANN": 0, // Announcements
-                    "PAT": 0, // Parking and transport
-                    "FEE": 0, // Feedback
-                    "FFD": 0, // Find a family doctor
-                    "MAS": 0, // Québec Medical Appointment Scheduler
-                    "EDU": 0, // Clinical reference material (educational material)
-                    "SUP": 1, // Opal support
-                    "SMD": 0, // Smart devices
-                    "CTB": 1, // Contribute to Opal development
-                    "RFE": 0, // Research feedback
-                },
                 localStorageHospitalKey: 'hospital',
-                hospitalList: [
+
+                // Hospitals available in development-level environments (e.g. dev, qa, staging)
+                developmentHospitalList: [
                     {
                         uniqueHospitalCode: 'A6',
                         enabled: true,
-                        acronymReal: 'NEURO_ACRONYM',
-                        fullNameReal: 'NEURO_FULL',
-                        acronymGeneric: 'OMI',
-                        fullNameGeneric: 'OMI_FULL',
+                        acronym: 'OMI',
+                        fullName: 'OMI_FULL',
+                        // Whether to kick out a user when another person logs into the same user account (in the same hospital) on another device
+                        kickOutConcurrentUsers: false,
+                        modules: {
+                            "_comment": "LIST OF MODULES ENABLED IN THIS HOSPITAL. MODULE_CODE: 0 = DISABLED; 1 = ENABLED; NO QUOTATION MARKS; SEE EXAMPLES BELOW",
+                            "DIA": 1, // Diagnoses
+                            "APT": 1, // Appointments
+                            "LAB": 1, // Lab results
+                            "DOC": 1, // Documents (clinical reports)
+                            "TTM": 1, // Treating team messages
+                            "QUE": 1, // Questionnaires
+                            "CSQ": 1, // Carnet Santé Québec
+                            "RES": 1, // Research menu
+                            "STU": 0, // Research studies
+                            "REF": 1, // Research reference material
+                            "RQU": 1, // Research questionnaires
+                            "CON": 1, // Research consent forms
+                            "CHK": 1, // Check-in
+                            "NTF": 1, // Notifications
+                            "ANN": 1, // Announcements
+                            "PAT": 1, // Parking and transport
+                            "FEE": 1, // Feedback
+                            "FFD": 1, // Find a family doctor
+                            "MAS": 1, // Québec Medical Appointment Scheduler
+                            "EDU": 1, // Clinical reference material (educational material)
+                            "SMD": 1, // Smart devices
+                            "RFE": 1, // Research feedback
+                        },
+                    },
+                ],
+
+                // Hospitals available in production-level environments (e.g. prod, preprod)
+                productionHospitalList: [
+                    {
+                        uniqueHospitalCode: 'A6',
+                        enabled: true,
+                        acronym: 'NEURO_ACRONYM',
+                        fullName: 'NEURO_FULL',
+                        kickOutConcurrentUsers: true,
                         modules: {
                             "_comment": "LIST OF MODULES ENABLED IN THIS HOSPITAL. MODULE_CODE: 0 = DISABLED; 1 = ENABLED; NO QUOTATION MARKS; SEE EXAMPLES BELOW",
                             "DIA": 1,
@@ -147,7 +158,6 @@
                             "RQU": 1,
                             "CON": 1,
                             "CHK": 1,
-                            "ABT": 1,
                             "NTF": 1,
                             "ANN": 1,
                             "PAT": 1,
@@ -155,59 +165,16 @@
                             "FFD": 1,
                             "MAS": 1,
                             "EDU": 1,
-                            "SUP": 1,
-                            "CED": 0,
-                            "HOS": 0,
                             "SMD": 1,
-                            "CTB": 1,
-                            "RFE": 1,
-                        },
-                    },
-                    {
-                        uniqueHospitalCode: 'A4',
-                        enabled: true,
-                        acronymReal: '',
-                        fullNameReal: '',
-                        acronymGeneric: 'OHIGPH',
-                        fullNameGeneric: 'OHIGPH_FULL',
-                        modules: {
-                            "_comment": "LIST OF MODULES ENABLED IN THIS HOSPITAL. MODULE_CODE: 0 = DISABLED; 1 = ENABLED; NO QUOTATION MARKS; SEE EXAMPLES BELOW",
-                            "DIA": 1,
-                            "APT": 1,
-                            "LAB": 1,
-                            "DOC": 0,
-                            "TTM": 1,
-                            "QUE": 1,
-                            "CSQ": 1,
-                            "RES": 0,
-                            "STU": 0,
-                            "REF": 1,
-                            "RQU": 0,
-                            "CON": 0,
-                            "CHK": 0,
-                            "ABT": 1,
-                            "NTF": 1,
-                            "ANN": 1,
-                            "PAT": 1,
-                            "FEE": 1,
-                            "FFD": 1,
-                            "MAS": 1,
-                            "EDU": 1,
-                            "SUP": 1,
-                            "CED": 0,
-                            "HOS": 0,
-                            "SMD": 0,
-                            "CTB": 1,
                             "RFE": 1,
                         },
                     },
                     {
                         uniqueHospitalCode: 'D1',
                         enabled: true,
-                        acronymReal: 'OPAL_DEMO_1',
-                        fullNameReal: 'OPAL_DEMO_1_FULL',
-                        acronymGeneric: 'OPAL_DEMO_1',
-                        fullNameGeneric: 'OPAL_DEMO_1_FULL',
+                        acronym: 'OPAL_DEMO_1',
+                        fullName: 'OPAL_DEMO_1_FULL',
+                        kickOutConcurrentUsers: false,
                         modules: {
                             "_comment": "LIST OF MODULES ENABLED IN THIS HOSPITAL. MODULE_CODE: 0 = DISABLED; 1 = ENABLED; NO QUOTATION MARKS; SEE EXAMPLES BELOW",
                             "DIA": 1,
@@ -223,7 +190,6 @@
                             "RQU": 1,
                             "CON": 1,
                             "CHK": 1,
-                            "ABT": 1,
                             "NTF": 1,
                             "ANN": 1,
                             "PAT": 1,
@@ -231,21 +197,16 @@
                             "FFD": 1,
                             "MAS": 1,
                             "EDU": 1,
-                            "SUP": 1,
-                            "CED": 0,
-                            "HOS": 0,
                             "SMD": 1,
-                            "CTB": 1,
                             "RFE": 1,
                         },
                     },
                     {
                         uniqueHospitalCode: 'D2',
                         enabled: true,
-                        acronymReal: 'OPAL_DEMO_2',
-                        fullNameReal: 'OPAL_DEMO_2_FULL',
-                        acronymGeneric: 'OPAL_DEMO_2',
-                        fullNameGeneric: 'OPAL_DEMO_2_FULL',
+                        acronym: 'OPAL_DEMO_2',
+                        fullName: 'OPAL_DEMO_2_FULL',
+                        kickOutConcurrentUsers: false,
                         modules: {
                             "_comment": "LIST OF MODULES ENABLED IN THIS HOSPITAL. MODULE_CODE: 0 = DISABLED; 1 = ENABLED; NO QUOTATION MARKS; SEE EXAMPLES BELOW",
                             "DIA": 1,
@@ -261,7 +222,6 @@
                             "RQU": 1,
                             "CON": 1,
                             "CHK": 1,
-                            "ABT": 1,
                             "NTF": 1,
                             "ANN": 1,
                             "PAT": 1,
@@ -269,21 +229,16 @@
                             "FFD": 1,
                             "MAS": 1,
                             "EDU": 1,
-                            "SUP": 1,
-                            "CED": 0,
-                            "HOS": 0,
                             "SMD": 1,
-                            "CTB": 1,
                             "RFE": 1,
                         },
                     },
                     {
                         uniqueHospitalCode: 'A0',
                         enabled: false,
-                        acronymReal: 'MUHC',
-                        fullNameReal: 'MUHC_FULL',
-                        acronymGeneric: 'MUHC',
-                        fullNameGeneric: 'MUHC_FULL',
+                        acronym: 'MUHC',
+                        fullName: 'MUHC_FULL',
+                        kickOutConcurrentUsers: true,
                         modules: {
                             "_comment": "LIST OF MODULES ENABLED IN THIS HOSPITAL. MODULE_CODE: 0 = DISABLED; 1 = ENABLED; NO QUOTATION MARKS; SEE EXAMPLES BELOW",
                             "DIA": 0,
@@ -307,11 +262,7 @@
                             "FFD": 0,
                             "MAS": 0,
                             "EDU": 0,
-                            "SUP": 0,
-                            "CED": 0,
-                            "HOS": 0,
                             "SMD": 0,
-                            "CTB": 0,
                             "RFE": 0,
                         },
                     },

--- a/src/js/controllers/about/aboutController.js
+++ b/src/js/controllers/about/aboutController.js
@@ -9,7 +9,6 @@
  * Date         :   18 Apr 2017
  */
 
-
 /**
  *  @ngdoc controller
  *  @description
@@ -34,37 +33,17 @@
 
         vm.openUrl = openUrl;
         vm.openTechnicalLegal = () => navigator.pushPage('views/init/technical-legal.html');
-        vm.openTour = openTour;
-        vm.allowedModules = {};
+        vm.openTour = () => navigator.pushPage('views/home/tour/tour.html');
 
         let parameters;
-        let isBeforeLogin = true;
 
         activate();
 
         ////////////////
 
         function activate() {
-
             parameters = Navigator.getParameters();
             navigator = Navigator.getNavigator();
-
-            /**
-             * about.html (About Opal) is called twice: once from init-Screen.html (very first screen) and once from home.html (after logging in)
-             * Different modules are enabled depending on whether it is called before or after login
-             * the parameter isBeforeLogin determines whether the page is called before login or after
-             * if the parameter isBeforeLogin is not passed, default to true
-             */
-            if (parameters.hasOwnProperty('isBeforeLogin')){
-                isBeforeLogin = parameters.isBeforeLogin;
-            }
-
-            // set the modules which are allowed to display depending on whether the user has logged in or not
-            if (isBeforeLogin){
-                vm.allowedModules = UserHospitalPreferences.getAllowedModulesBeforeLogin();
-            } else {
-                vm.allowedModules = UserHospitalPreferences.getHospitalAllowedModules();
-            }
 
             vm.language = UserPreferences.getLanguage();
         }
@@ -72,10 +51,6 @@
         function openUrl(contentKey, openInExternalBrowser = false) {
             const url = DynamicContent.getURL(contentKey);
             openInExternalBrowser ? Browser.openExternal(url) : Browser.openInternal(url);
-        }
-
-        function openTour() {
-            navigator.pushPage('views/home/tour/tour.html');
         }
     }
 })();

--- a/src/js/controllers/auth/setHospitalController.js
+++ b/src/js/controllers/auth/setHospitalController.js
@@ -31,7 +31,7 @@
         ////////////////
 
         function activate() {
-            vm.hospitalList = UserHospitalPreferences.getHospitalListForDisplay();
+            vm.hospitalList = UserHospitalPreferences.getHospitalList();
             hospitalMessages = DynamicContent.getConstant('hospitalMessages');
             language = UserPreferences.getLanguage();
 

--- a/src/js/controllers/home/homeController.js
+++ b/src/js/controllers/home/homeController.js
@@ -234,7 +234,7 @@
          * @desc Go to the About Opal page
          */
         function goToAboutOpal() {
-            homeNavigator.pushPage('./views/home/about/about.html', {'isBeforeLogin': false});
+            homeNavigator.pushPage('./views/home/about/about.html');
         }
 
         /**

--- a/src/js/controllers/init/initScreenController.js
+++ b/src/js/controllers/init/initScreenController.js
@@ -56,7 +56,7 @@ import '../../../css/views/init-page.view.css';
 		vm.APP_VERSION = Constants.version();
 		vm.APP_BUILD_NUMBER = Constants.build();
 
-		vm.goToAboutOpal = () => initNavigator.pushPage('./views/home/about/about.html', {'isBeforeLogin': true});
+		vm.goToAboutOpal = () => initNavigator.pushPage('./views/home/about/about.html');
 		vm.goToRegister = goToRegister;
 		vm.goToTechnicalLegal = () => initNavigator.pushPage('views/init/technical-legal.html');
 		vm.goToPartners = goToPartners;

--- a/src/views/home/about/about.html
+++ b/src/views/home/about/about.html
@@ -41,7 +41,7 @@ SPDX-License-Identifier: Apache-2.0
         </ons-list-item>
 
         <!-- CONTRIBUTE -->
-        <ons-list-item class="item" modifier="tappable" ng-click="about.openUrl('donation', true)" ng-show="about.allowedModules.hasOwnProperty('CTB') && about.allowedModules['CTB']">
+        <ons-list-item class="item" modifier="tappable" ng-click="about.openUrl('donation', true)">
             <ons-row align="center">
                 <ons-col width="60px" style="text-align: center">
                     <div>
@@ -58,7 +58,7 @@ SPDX-License-Identifier: Apache-2.0
         </ons-list-item>
 
         <!-- CONTACT SUPPORT -->
-        <ons-list-item class="item" modifier="tappable" ng-click="about.openUrl('support', true)" ng-show="about.allowedModules.hasOwnProperty('SUP') && about.allowedModules['SUP']">
+        <ons-list-item class="item" modifier="tappable" ng-click="about.openUrl('support', true)">
             <ons-row align="center">
                 <ons-col width="60px" style="text-align: center">
                     <div>

--- a/src/views/home/home.html
+++ b/src/views/home/home.html
@@ -60,7 +60,7 @@ SPDX-License-Identifier: Apache-2.0
             ABOUT OPAL
             ================================
             -->
-            <ons-list-item modifier="chevron tappable" class="item" ng-if="Ctrl.allowedModules.hasOwnProperty('ABT') && Ctrl.allowedModules['ABT']" ng-click="Ctrl.goToAboutOpal()">
+            <ons-list-item modifier="chevron tappable" class="item" ng-click="Ctrl.goToAboutOpal()">
                 <ons-row align="center">
                     <ons-col class="home-view--list--icon">
                         <img class="home-view--opal--logo" src="img/Opal_Logo_Transparent_Inverse_Icon.png">


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the conventional commits convention (see `Backend` project's `README.md`)
  - `feat`: minor app version will be incremented.
  - `fix`, `deps`, `perf`: patch app version will be incremented.
  - `chore`, `ci`, etc.: app version will not be incremented.
  - See [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)
    for complete set of rules.

### Changes
<!-- Summary of the changes in this MR. -->
Updated the setting used to kick out concurrent users, by turning it into a hospital-specific configuration (and disabled this setting for the Demo hospitals). Also reorganized the app's hospital list, which was becoming overly complicated, by splitting it into a production list and a development list.

Other changes:
  - Removed unused `OHIGPH` hospital.
  - Removed `allowedModulesBeforeLogin`, which is no longer needed now that the `About Opal` page doesn't contain hospital-specific information.

### Dependencies
<!-- Link to dependent pull requests. Specify whether the MRs are just related, or require each other to run. Write N/A if there are none. -->
- **Listener**: N/A

Fixes #1371 