### PR TITLE
ci: calculate build number based on the commit history

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -61,10 +61,11 @@ runs:
         COMMIT_DISTANCE=$(git rev-list --count $LATEST_TAG..HEAD)
         NEW_BUILD_NUMBER=$((COMMIT_DISTANCE + 1))
         if [ "$IS_ON_MAIN" = true ]; then
+          echo "Calculating build number"
           BUILD_NUMBER=$NEW_BUILD_NUMBER
         else
-          BUILD_NUMBER=1
           echo "Execution is not on the main branch, defaulting to 1"
+          BUILD_NUMBER=1
         fi
         echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
         echo "Using build number = ($BUILD_NUMBER)"

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -49,3 +49,28 @@ runs:
       env:
         ENV_CONFIG_JS: ${{ inputs.ENV_CONFIG_JS }}
         ENV_GOOGLE_SERVICES: ${{ inputs.ENV_GOOGLE_SERVICES }}
+
+    # Calculate the app's build number, for example the number '2' in 1.0.0 (2).
+    - name: Calculate build number
+      id: calculate-build-number
+      # Calculate the number of commits (inclusive) between the last tagged version (e.g. v2.0.0) and the current commit
+      # This represents the build number; for example, the first commit tagged v2.0.0 will be 2.0.0 (1). The next commit will be 2.0.0 (2), and so on, until the next tag.
+      # This is only applicable on the 'main' branch; if not on main, use default value '1'
+      run: |
+        LATEST_TAG=$(git describe --tags --abbrev=0 --match v*)
+        COMMIT_DISTANCE=$(git rev-list --count $LATEST_TAG..HEAD)
+        NEW_BUILD_NUMBER=$((COMMIT_DISTANCE + 1))
+        [ $IS_ON_MAIN ] && BUILD_NUMBER=$NEW_BUILD_NUMBER || BUILD_NUMBER=1
+        echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+      shell: bash
+      env:
+        IS_ON_MAIN: ${{ github.ref_name == 'main' }}
+
+    # Replace the build number in the file opal.config.js with the newly calculated value.
+    - name: Replace build number in opal.config.js
+      run: |
+        sed -i -E "s/\"BUILD_NUMBER\"\: .+\,/\"BUILD_NUMBER\"\: ${BUILD_NUMBER}\,/" test.js
+        cat env/$ENVIRONMENT/opal.config.js
+      shell: bash
+      env:
+        BUILD_NUMBER: ${{ steps.calculate-build-number.outputs.BUILD_NUMBER }}

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -60,7 +60,12 @@ runs:
         LATEST_TAG=$(git describe --tags --abbrev=0 --match v*)
         COMMIT_DISTANCE=$(git rev-list --count $LATEST_TAG..HEAD)
         NEW_BUILD_NUMBER=$((COMMIT_DISTANCE + 1))
-        if [ "$IS_ON_MAIN" = true ]; then BUILD_NUMBER=$NEW_BUILD_NUMBER"; else BUILD_NUMBER=1 && echo "Execution is not on the main branch, defaulting to 1"; fi
+        if [ "$IS_ON_MAIN" = true ]; then
+          BUILD_NUMBER=$NEW_BUILD_NUMBER"
+        else
+          BUILD_NUMBER=1
+          echo "Execution is not on the main branch, defaulting to 1"
+        fi
         echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
         echo "Using build number = ($BUILD_NUMBER)"
       shell: bash

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -60,7 +60,7 @@ runs:
         LATEST_TAG=$(git describe --tags --abbrev=0 --match v*)
         COMMIT_DISTANCE=$(git rev-list --count $LATEST_TAG..HEAD)
         NEW_BUILD_NUMBER=$((COMMIT_DISTANCE + 1))
-        if [ "$IS_ON_MAIN" = true ]; then BUILD_NUMBER=$NEW_BUILD_NUMBER; else BUILD_NUMBER=1; fi
+        if [ "$IS_ON_MAIN" = true ]; then BUILD_NUMBER=$NEW_BUILD_NUMBER"; else BUILD_NUMBER=1 && echo "Execution is not on the main branch, defaulting to 1"; fi
         echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
         echo "Using build number = ($BUILD_NUMBER)"
       shell: bash

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -61,7 +61,7 @@ runs:
         COMMIT_DISTANCE=$(git rev-list --count $LATEST_TAG..HEAD)
         NEW_BUILD_NUMBER=$((COMMIT_DISTANCE + 1))
         if [ "$IS_ON_MAIN" = true ]; then
-          BUILD_NUMBER=$NEW_BUILD_NUMBER"
+          BUILD_NUMBER=$NEW_BUILD_NUMBER
         else
           BUILD_NUMBER=1
           echo "Execution is not on the main branch, defaulting to 1"

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -86,8 +86,7 @@ runs:
         echo "Using build number = ($BUILD_NUMBER)"
       shell: bash
       env:
-        # TODO testing
-        IS_ON_MAIN: ${{ github.ref_name == 'SB.ci-cd-build-number' }}
+        IS_ON_MAIN: ${{ github.ref_name == 'main' }}
 
     # Replace the build number in the file opal.config.js with the newly calculated value.
     - name: Replace build number in opal.config.js

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -62,6 +62,7 @@ runs:
         NEW_BUILD_NUMBER=$((COMMIT_DISTANCE + 1))
         [ $IS_ON_MAIN ] && BUILD_NUMBER=$NEW_BUILD_NUMBER || BUILD_NUMBER=1
         echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+        echo "Using build number = ($BUILD_NUMBER)"
       shell: bash
       env:
         IS_ON_MAIN: ${{ github.ref_name == 'main' }}
@@ -70,7 +71,7 @@ runs:
     - name: Replace build number in opal.config.js
       run: |
         sed -i -E "s/\"BUILD_NUMBER\"\: .+\,/\"BUILD_NUMBER\"\: ${BUILD_NUMBER}\,/" env/$ENVIRONMENT/opal.config.js
-        cat env/$ENVIRONMENT/opal.config.js
+        grep BUILD_NUMBER env/$ENVIRONMENT/opal.config.js
       shell: bash
       env:
         BUILD_NUMBER: ${{ steps.calculate-build-number.outputs.BUILD_NUMBER }}

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -71,7 +71,8 @@ runs:
         echo "Using build number = ($BUILD_NUMBER)"
       shell: bash
       env:
-        IS_ON_MAIN: ${{ github.ref_name == 'main' }}
+        # TODO testing
+        IS_ON_MAIN: ${{ github.ref_name == 'SB.ci-cd-build-number' }}
 
     # Replace the build number in the file opal.config.js with the newly calculated value.
     - name: Replace build number in opal.config.js

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -50,6 +50,21 @@ runs:
         ENV_CONFIG_JS: ${{ inputs.ENV_CONFIG_JS }}
         ENV_GOOGLE_SERVICES: ${{ inputs.ENV_GOOGLE_SERVICES }}
 
+    # Setup for the next step, calculate-build-number
+    # Ensure the sed command works the same way on Linux and Mac by installing gnu-sed on Mac
+    - name: Install gnu-sed if running on macOS
+      run: |
+        if [ "$IS_ON_MACOS" == "true" ]; then
+          echo "Installing gnu-sed"
+          brew install gnu-sed
+          echo PATH="/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH" >> $GITHUB_ENV
+        else
+          echo "Not on macOS, using default sed"
+        fi
+      shell: bash
+      env:
+        IS_ON_MACOS: ${{ runner.os == 'macOS' }}
+
     # Calculate the app's build number, for example the number '2' in 1.0.0 (2).
     - name: Calculate build number
       id: calculate-build-number

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -60,7 +60,7 @@ runs:
         LATEST_TAG=$(git describe --tags --abbrev=0 --match v*)
         COMMIT_DISTANCE=$(git rev-list --count $LATEST_TAG..HEAD)
         NEW_BUILD_NUMBER=$((COMMIT_DISTANCE + 1))
-        [ $IS_ON_MAIN ] && BUILD_NUMBER=$NEW_BUILD_NUMBER || BUILD_NUMBER=1
+        if [ "$IS_ON_MAIN" = true ]; then BUILD_NUMBER=$NEW_BUILD_NUMBER; else BUILD_NUMBER=1; fi
         echo "BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
         echo "Using build number = ($BUILD_NUMBER)"
       shell: bash

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -69,7 +69,7 @@ runs:
     # Replace the build number in the file opal.config.js with the newly calculated value.
     - name: Replace build number in opal.config.js
       run: |
-        sed -i -E "s/\"BUILD_NUMBER\"\: .+\,/\"BUILD_NUMBER\"\: ${BUILD_NUMBER}\,/" test.js
+        sed -i -E "s/\"BUILD_NUMBER\"\: .+\,/\"BUILD_NUMBER\"\: ${BUILD_NUMBER}\,/" env/$ENVIRONMENT/opal.config.js
         cat env/$ENVIRONMENT/opal.config.js
       shell: bash
       env:

--- a/.github/workflows/build-deploy-app.yml
+++ b/.github/workflows/build-deploy-app.yml
@@ -51,6 +51,9 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
+          # Fetch part of the commit history and its tags, in order to calculate the build number in `build-setup`
+          fetch-depth: 100
+          fetch-tags: true
       - name: Set up build
         uses: ./.github/actions/build-setup
         with:
@@ -85,6 +88,9 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
+          # Fetch part of the commit history and its tags, in order to calculate the build number in `build-setup`
+          fetch-depth: 100
+          fetch-tags: true
       - name: Set up build
         uses: ./.github/actions/build-setup
         with:

--- a/.github/workflows/build-deploy-app.yml
+++ b/.github/workflows/build-deploy-app.yml
@@ -12,8 +12,6 @@ on:
   push:
     branches:
       - main
-      # TODO testing
-      - SB.ci-cd-build-number
 
   # Offer a manual interface to build for all other environments as needed
   workflow_dispatch:

--- a/.github/workflows/build-deploy-app.yml
+++ b/.github/workflows/build-deploy-app.yml
@@ -13,7 +13,7 @@ on:
     branches:
       - main
       # TODO testing
-      - SB.ci-cd-versioning
+      - SB.ci-cd-build-number
 
   # Offer a manual interface to build for all other environments as needed
   workflow_dispatch:

--- a/.github/workflows/build-deploy-app.yml
+++ b/.github/workflows/build-deploy-app.yml
@@ -12,6 +12,8 @@ on:
   push:
     branches:
       - main
+      # TODO testing
+      - SB.ci-cd-versioning
 
   # Offer a manual interface to build for all other environments as needed
   workflow_dispatch:

--- a/.github/workflows/build-deploy-web.yml
+++ b/.github/workflows/build-deploy-web.yml
@@ -51,7 +51,6 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
-          # TODO add to build-deploy-app
           # Fetch part of the commit history and its tags, in order to calculate the build number in `build-setup`
           fetch-depth: 100
           fetch-tags: true

--- a/.github/workflows/build-deploy-web.yml
+++ b/.github/workflows/build-deploy-web.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - main
       # TODO testing
-      - SB.ci-cd-versioning
+      - SB.ci-cd-build-number
 
   # When updating a pull request or adding a pull request to a merge queue, automatically build for dev
   pull_request:

--- a/.github/workflows/build-deploy-web.yml
+++ b/.github/workflows/build-deploy-web.yml
@@ -51,6 +51,10 @@ jobs:
       - uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
+          # TODO add to build-deploy-app
+          # Fetch part of the commit history and its tags, in order to calculate the build number in `build-setup`
+          fetch-depth: 100
+          fetch-tags: true
       - name: Set up build
         uses: ./.github/actions/build-setup
         with:

--- a/.github/workflows/build-deploy-web.yml
+++ b/.github/workflows/build-deploy-web.yml
@@ -10,8 +10,6 @@ on:
   push:
     branches:
       - main
-      # TODO testing
-      - SB.ci-cd-build-number
 
   # When updating a pull request or adding a pull request to a merge queue, automatically build for dev
   pull_request:

--- a/.github/workflows/build-deploy-web.yml
+++ b/.github/workflows/build-deploy-web.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+      # TODO testing
+      - SB.ci-cd-versioning
 
   # When updating a pull request or adding a pull request to a merge queue, automatically build for dev
   pull_request:

--- a/.github/workflows/build-deploy-web.yml
+++ b/.github/workflows/build-deploy-web.yml
@@ -74,7 +74,6 @@ jobs:
     needs: build-web
     runs-on: ubuntu-latest
     # Deploy manually via inputs, or automatically (to dev) when building on main
-    # TODO test github.ref_name
     if: ${{ inputs.DEPLOY || github.ref_name == 'main' }}
     steps:
       # Setup


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the conventional commits convention (see `Backend` project's `README.md`)
  - `feat`: minor app version will be incremented.
  - `fix`, `deps`, `perf`: patch app version will be incremented.
  - `chore`, `ci`, etc.: app version will not be incremented.
  - See [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)
    for complete set of rules.

### Changes
<!-- Summary of the changes in this MR. -->
Added steps to the `build-setup` action to calculate a build number based on the number of commits between tags. For example, the first commit tagged v2.0.0 will be 2.0.0 (1). The next commit will be 2.0.0 (2), and so on, until the next tag.

### Dependencies
<!-- Link to dependent pull requests. Specify whether the MRs are just related, or require each other to run. Write N/A if there are none. -->
- **Listener**: N/A