### PR TITLE
ci: configure the git commit author for semantic-release commits

### DIFF
--- a/.github/workflows/increment-version.yml
+++ b/.github/workflows/increment-version.yml
@@ -32,3 +32,8 @@ jobs:
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Configure the commit author/committer to have access to commit to the repository
+          GIT_AUTHOR_EMAIL: ${{ vars.SEMANTIC_RELEASE_GIT_EMAIL }}
+          GIT_AUTHOR_NAME: ${{ vars.SEMANTIC_RELEASE_GIT_NAME }}
+          GIT_COMMITTER_EMAIL: ${{ vars.SEMANTIC_RELEASE_GIT_EMAIL }}
+          GIT_COMMITTER_NAME: ${{ vars.SEMANTIC_RELEASE_GIT_NAME }}


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the conventional commits convention (see `Backend` project's `README.md`)
  - `feat`: minor app version will be incremented.
  - `fix`, `deps`, `perf`: patch app version will be incremented.
  - `chore`, `ci`, etc.: app version will not be incremented.
  - See [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)
    for complete set of rules.

### Changes
<!-- Summary of the changes in this MR. -->
Configured the git commit author and committer for semantic-release commits to ensure that this user has write access to the repository. This user will be set to `opalmedapps-bot` via Actions variables.
