### PR TITLE
fix: add viewer URL to allowed URLs for iOS ATS

### DIFF
--- a/env/config.xml
+++ b/env/config.xml
@@ -26,6 +26,7 @@ SPDX-License-Identifier: Apache-2.0
         See: https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/
     -->
     <allow-navigation href="https://www.youtube.com/*" requires-certificate-transparency="true"/>
+    <allow-navigation href="https://viewer.opalmedapps.ca/*" requires-certificate-transparency="true"/>
     <allow-intent href="https://*/*"/>
     <allow-intent href="tel:*"/>
     <allow-intent href="sms:*"/>


### PR DESCRIPTION
This is needed to make iOS allow connections to this URL. App Transport Security will otherwise block those connections.

Also sneaking in an update to the deployment target for iOS to raise it to `12.0`.