### PR TITLE
fix: add an "open" icon to Security and Privacy

### DIFF
--- a/src/views/init/technical-legal.html
+++ b/src/views/init/technical-legal.html
@@ -11,8 +11,10 @@ SPDX-License-Identifier: Apache-2.0
         <ons-list-item modifier = "chevron" ng-hide="init.navigatorName == 'initNavigator'" ng-click="init.goToFeedback()">
             {{"FEEDBACK"|translate}}
         </ons-list-item>
-        <ons-list-item modifier="chevron" ng-click="init.openSecurityAndPrivacy()">
+        <ons-list-item ng-click="init.openSecurityAndPrivacy()">
             {{"SECURITY_AND_PRIVACY"|translate}}
+            <ons-icon icon="ion-android-open" style="color:#ddd; padding: 10px 5px" class="pull-right" size="1.2em">
+            </ons-icon>
         </ons-list-item>
         <ons-list-item modifier="chevron" ng-click="init.openPageLegal('termsOfUse')">
             {{"TERMS_OF_USE"|translate}}


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the conventional commits convention (see `Backend` project's `README.md`)
  - `feat`: minor app version will be incremented.
  - `fix`, `deps`, `perf`: patch app version will be incremented.
  - `chore`, `ci`, etc.: app version will not be incremented.
  - See [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)
    for complete set of rules.

### Changes
<!-- Summary of the changes in this MR. -->
Updated the chevron on `Security and Privacy` to an "open" icon for consistency, now that this button opens a URL instead of a content page.

### Dependencies
<!-- Link to dependent pull requests. Specify whether the MRs are just related, or require each other to run. Write N/A if there are none. -->
- **App**:  Follows an update made in opalmedapps#1349 to open `securityAndPrivacy` via an external URL.
