### PR TITLE
ci: add build number override option for web builds

### DIFF
--- a/.github/workflows/build-deploy-app.yml
+++ b/.github/workflows/build-deploy-app.yml
@@ -6,7 +6,7 @@
 
 name: Build and Deploy App
 # Default to dev when running automatically (see also "env" below)
-run-name: Building ${{ (inputs.DEPLOY_FIREBASE || inputs.DEPLOY_STORES) && 'and deploying ' || '' }}the mobile app for ${{ inputs.ENVIRONMENT || 'dev' }} 📦🚀
+run-name: Building ${{ (inputs.DEPLOY_FIREBASE || inputs.DEPLOY_STORES) && 'and deploying ' || '' }}the mobile app for ${{ inputs.ENVIRONMENT || 'dev' }}
 on:
   # When pushing to main, automatically build for dev
   push:

--- a/.github/workflows/build-deploy-web.yml
+++ b/.github/workflows/build-deploy-web.yml
@@ -4,7 +4,7 @@
 
 name: Build and Deploy Web
 # Default to dev when running automatically (see also "env" below)
-run-name: Building ${{ inputs.DEPLOY && 'and deploying ' || '' }}the web app for ${{ inputs.ENVIRONMENT || 'dev' }} 📦🚀
+run-name: Building ${{ inputs.DEPLOY && 'and deploying ' || '' }}the web app for ${{ inputs.ENVIRONMENT || 'dev' }}
 on:
   # When pushing to main, automatically build for dev
   push:


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the conventional commits convention (see `Backend` project's `README.md`)
  - `feat`: minor app version will be incremented.
  - `fix`, `deps`, `perf`: patch app version will be incremented.
  - `chore`, `ci`, etc.: app version will not be incremented.
  - See [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)
    for complete set of rules.

### Changes
<!-- Summary of the changes in this MR. -->
Added a build number override option for web builds (via `workflow_dispatch`), to allow the web app to be deployed with a specific build number. This is useful especially when releasing to the stores, to produce a web build with a number matching the one in the stores.