### PR TITLE
chore: add preset for pre-commit hooks to be updated by Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,7 @@
     // https://docs.renovatebot.com/presets-schedule/#scheduleweekly
     "schedule:weekly",
     "github>mschoettle/renovate-presets//presets/actions-dependency-version.json5",
+    "github>mschoettle/renovate-presets//presets/pre-commit-hooks.json5",
   ],
   // Extra rules for node images. See: https://github.com/renovatebot/renovate/discussions/29501
   // Ensure that node docker versioning doesn't interfere with the custom managers.


### PR DESCRIPTION
**By submitting this merge request, I confirm the following:**

* [x] The merge request title follows the conventional commits convention (see `Backend` project's `README.md`)
  - `feat`: minor app version will be incremented.
  - `fix`, `deps`, `perf`: patch app version will be incremented.
  - `chore`, `ci`, etc.: app version will not be incremented.
  - See [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)
    for complete set of rules.

### Changes
<!-- Summary of the changes in this MR. -->
Added `pre-commit-hooks.json5` from `mschoettle/renovate-presets` to the Renovate config to manage pre-commit hook updates automatically.

### Dependencies
<!-- Link to dependent pull requests. Specify whether the MRs are just related, or require each other to run. Write N/A if there are none. -->
- **Listener**: N/A